### PR TITLE
removed UIWebView reference

### DIFF
--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -518,9 +518,6 @@ NSTimer *timer;
 }
 
 // This forwards the methods that are in the header that are not implemented here.
-// Both WKWebView and UIWebView implement the below:
-//     loadHTMLString:baseURL:
-//     loadRequest:
 - (id)forwardingTargetForSelector:(SEL)aSelector
 {
     return _engineWebView;


### PR DESCRIPTION
As clarified here: https://blog.ionicframework.com/understanding-itms-90809-uiwebview-api-deprecation/

Apple searches for the keyword "UIWebView" even in code that is commented out.